### PR TITLE
Adding example for double quotes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,3 +2,9 @@ cc_binary(
     name = "bin",
     srcs = ["source_name with_space.cpp"],
 )
+
+#cc_binary(
+#    name = "bin",
+#    local_defines = ["LOCALDEFINE=\"helloworld\""],
+#    srcs = ["source_name.cpp"],
+#)

--- a/source_name.cpp
+++ b/source_name.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+using namespace std;
+
+int main(int argc, char** argv, char * envp[]) {
+    cout << LOCALDEFINE << endl;
+    return 0;
+}


### PR DESCRIPTION
Adding failure escaping example for double quotes.

To use:
1. Comment other cc_binary above.
2. Uncomment the cc_binary with double quotes in the local_defines
3. run bazel build bin  --features=compiler_param_file
4. You should get error
5. check bazel-bin\_objs\bin\source_name.obj.params, you will find /DLOCALDEFINE=helloworld. The failure is because of helloworld is un-escaped.